### PR TITLE
Use new logo as application icon

### DIFF
--- a/TileIconifier/TileIconifier.WinForms.csproj
+++ b/TileIconifier/TileIconifier.WinForms.csproj
@@ -85,6 +85,9 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>Resources\tiles2_shadow_lyk_icon.ico</ApplicationIcon>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
quick change to use the new logo as the Windows application icon, feel free to implement yourself if you'd rather not pull in the change