### PR TITLE
Fix misaligned checkmark in main menu

### DIFF
--- a/TileIconifier/Forms/Main/FrmMain.Designer.cs
+++ b/TileIconifier/Forms/Main/FrmMain.Designer.cs
@@ -165,7 +165,6 @@ namespace TileIconifier.Forms.Main
             // 
             // mnuMain
             // 
-            this.mnuMain.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.mnuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.preferencesToolStripMenuItem,


### PR DESCRIPTION
This is a tiny fix for the misaligned checkmarks in the main menu of FrmMain. The issue was introduced in commit 9a3abdecc934e322d696225adcc492c1a62d6ab9, which sets the icon size to 24 by 24 instead of the default 16x16. 

Before this fix:
![image](https://user-images.githubusercontent.com/25092585/37182070-a65de318-22fd-11e8-8cdd-f75c926fecda.png)

After:
![image](https://user-images.githubusercontent.com/25092585/37182074-aada6a88-22fd-11e8-9036-4c6fc6949f1d.png)

I suspect that the change was silently made by the WinForms designer while you were working on other things. In my experience, the designer tends to cause problems like this when the Windows scaling setting is not 100%. Any chance that is what happened here?