### PR TITLE
Get shortcut arguments and icon path to use when quick building custom shortcut

### DIFF
--- a/TileIconifier.Core/Custom/Steam/SteamLibrary.cs
+++ b/TileIconifier.Core/Custom/Steam/SteamLibrary.cs
@@ -187,7 +187,7 @@ namespace TileIconifier.Core.Custom.Steam
 
             if (SteamShortcutItem != null)
             {
-                return SteamShortcutItem.TargetFilePath;
+                return SteamShortcutItem.TargetInfo.FilePath;
             }
             var assumedSteamExePath = _steamInstallationFolderPath + "Steam.exe";
             if (File.Exists(assumedSteamExePath))

--- a/TileIconifier.Core/Shortcut/ShortcutItem.cs
+++ b/TileIconifier.Core/Shortcut/ShortcutItem.cs
@@ -75,7 +75,7 @@ namespace TileIconifier.Core.Shortcut
                 }
                 try
                 {
-                    return CustomShortcut.Load(TargetFilePath);
+                    return CustomShortcut.Load(TargetInfo.FilePath);
                 }
                 catch
                 {
@@ -96,7 +96,7 @@ namespace TileIconifier.Core.Shortcut
             }
         }
 
-        public bool IsValidForIconification => !string.IsNullOrEmpty(TargetFilePath) && File.Exists(TargetFilePath);
+        public bool IsValidForIconification => !string.IsNullOrEmpty(TargetInfo.FilePath) && File.Exists(TargetInfo.FilePath);
 
         //todo: merge this with property IconifiedByTileIconifier at some point, should be a better indicator but won't work retroactively
         public bool IsIconified => File.Exists(VisualElementManifestPath)
@@ -151,39 +151,39 @@ namespace TileIconifier.Core.Shortcut
 
         #region Path properties
 
-        private string _targetFilePath;
+        private ShortcutItemTarget _targetInfo = new ShortcutItemTarget();
 
-        public string TargetFilePath
+        public ShortcutItemTarget TargetInfo
         {
             get
             {
-                if (string.IsNullOrEmpty(_targetFilePath))
+                if (string.IsNullOrEmpty(_targetInfo.FilePath))
                 {
-                    _targetFilePath = ShortcutUtils.GetTargetPath(ShortcutFileInfo.FullName);
+                    _targetInfo = ShortcutUtils.GetTargetInfo(ShortcutFileInfo.FullName);
                 }
 
                 return
                     Environment.ExpandEnvironmentVariables("%PATHEXT%").Split(';').Any(
                         e =>
-                            string.Equals(Path.GetExtension(_targetFilePath), e,
+                            string.Equals(Path.GetExtension(_targetInfo.FilePath), e,
                                 StringComparison.InvariantCultureIgnoreCase))
-                        ? _targetFilePath
-                        : null;
+                        ? _targetInfo
+                        : new ShortcutItemTarget();
             }
         }
 
         public string VisualElementManifestPath =>
-            $"{TargetFolderPath}{Path.GetFileNameWithoutExtension(TargetFilePath)}.VisualElementsManifest.xml";
+            $"{TargetFolderPath}{Path.GetFileNameWithoutExtension(TargetInfo.FilePath)}.VisualElementsManifest.xml";
 
         public string VisualElementManifestPathOriginalBackup =>
             VisualElementManifestPath + ".originalbak";
 
-        public string TargetFolderPath => Path.GetDirectoryName(TargetFilePath) + "\\";
+        public string TargetFolderPath => Path.GetDirectoryName(TargetInfo.FilePath) + "\\";
 
         public string VisualElementsPath => TargetFolderPath + @"\VisualElements\";
 
         public string MediumIconName
-            => $"MediumIcon{Path.GetFileNameWithoutExtension(TargetFilePath)}.png";
+            => $"MediumIcon{Path.GetFileNameWithoutExtension(TargetInfo.FilePath)}.png";
 
         public string RelativeMediumIconPath
             => $"{Path.GetFileName(Path.GetDirectoryName(VisualElementsPath))}\\{MediumIconName}";
@@ -191,7 +191,7 @@ namespace TileIconifier.Core.Shortcut
         public string FullMediumIconPath => $"{VisualElementsPath}{MediumIconName}";
 
         public string SmallIconName
-            => $"SmallIcon{Path.GetFileNameWithoutExtension(TargetFilePath)}.png";
+            => $"SmallIcon{Path.GetFileNameWithoutExtension(TargetInfo.FilePath)}.png";
 
         public string RelativeSmallIconPath
             => $"{Path.GetFileName(Path.GetDirectoryName(VisualElementsPath))}\\{SmallIconName}";

--- a/TileIconifier.Core/Shortcut/ShortcutItemEnumeration.cs
+++ b/TileIconifier.Core/Shortcut/ShortcutItemEnumeration.cs
@@ -216,7 +216,7 @@ namespace TileIconifier.Core.Shortcut
                 if (!string.IsNullOrEmpty(DesktopApplicationId))
                 {
                     matchingShortcutItems.AddRange(_shortcutsCache.Where(
-                        s => Path.GetFullPath(Environment.ExpandEnvironmentVariables(s.TargetFilePath)) ==
+                        s => Path.GetFullPath(Environment.ExpandEnvironmentVariables(s.TargetInfo.FilePath)) ==
                              Path.GetFullPath(Environment.ExpandEnvironmentVariables(DesktopApplicationId))));
                     matchingShortcutItems.AddRange(shortcutsCache.Where(s => s.AppId == DesktopApplicationId));
                 }

--- a/TileIconifier.Core/Shortcut/ShortcutItemTarget.cs
+++ b/TileIconifier.Core/Shortcut/ShortcutItemTarget.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TileIconifier.Core.Shortcut
+{
+    [Serializable]
+    public class ShortcutItemTarget
+    {
+        public string FilePath { get; set; }
+        public string Arguments { get; set; }
+        public string IconLocation { get; set; }
+    }
+}

--- a/TileIconifier.Core/TileIconifier.Core.csproj
+++ b/TileIconifier.Core/TileIconifier.Core.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Shortcut\ShortcutItem.cs" />
     <Compile Include="Shortcut\ShortcutItemEnumeration.cs" />
     <Compile Include="Shortcut\ShortcutItemImage.cs" />
+    <Compile Include="Shortcut\ShortcutItemTarget.cs" />
     <Compile Include="Shortcut\State\ShortcutItemState.cs" />
     <Compile Include="Shortcut\State\ShortcutItemStateController.cs" />
     <Compile Include="TileIconify\TileIcon.cs" />

--- a/TileIconifier.Core/TileIconify/TileIcon.cs
+++ b/TileIconifier.Core/TileIconify/TileIcon.cs
@@ -142,7 +142,7 @@ namespace TileIconifier.Core.TileIconify
             }
 
             var manifestPath =
-                $"{_shortcutItem.TargetFolderPath}\\{Path.GetFileNameWithoutExtension(_shortcutItem.TargetFilePath)}.VisualElementsManifest.xml";
+                $"{_shortcutItem.TargetFolderPath}\\{Path.GetFileNameWithoutExtension(_shortcutItem.TargetInfo.FilePath)}.VisualElementsManifest.xml";
 
             if (File.Exists(manifestPath))
             {

--- a/TileIconifier/Controls/IconifierPanel/TileIconifierPanel.cs
+++ b/TileIconifier/Controls/IconifierPanel/TileIconifierPanel.cs
@@ -203,19 +203,19 @@ namespace TileIconifier.Controls.IconifierPanel
                     {
                         try
                         {
-                            var customShortcutExecutionTarget = CustomShortcut.Load(CurrentShortcutItem.TargetFilePath);
+                            var customShortcutExecutionTarget = CustomShortcut.Load(CurrentShortcutItem.TargetInfo.FilePath);
                             imagePath = customShortcutExecutionTarget.TargetPath.UnQuoteWrap();
                         }
                         catch (InvalidCustomShortcutException)
                         {
                             //corrupted custom shortcut?
-                            imagePath = CurrentShortcutItem.TargetFilePath;
+                            imagePath = CurrentShortcutItem.TargetInfo.FilePath;
                         }
                     }
                     else
                     {
                         //otherwise we just use the target file path from the shortcut
-                        imagePath = CurrentShortcutItem.TargetFilePath;
+                        imagePath = CurrentShortcutItem.TargetInfo.FilePath;
                     }
                 }
                 selectedImage = FrmIconSelector.GetImage(this, imagePath);

--- a/TileIconifier/Forms/Main/FrmMain.cs
+++ b/TileIconifier/Forms/Main/FrmMain.cs
@@ -242,10 +242,11 @@ namespace TileIconifier.Forms.Main
 
             shortcutName = cloneConfirmation.ShortcutName;
 
-            var parameters = new GenerateCustomShortcutParams(CurrentShortcutItem.TargetFilePath, string.Empty,
+            var parameters = new GenerateCustomShortcutParams(CurrentShortcutItem.TargetInfo.FilePath, CurrentShortcutItem.TargetInfo.Arguments,
                 CustomShortcutGetters.CustomShortcutCurrentUserPath)
             {
-                WorkingFolder = CurrentShortcutItem.ShortcutFileInfo.Directory?.FullName
+                WorkingFolder = CurrentShortcutItem.ShortcutFileInfo.Directory?.FullName,
+                IconPath = CurrentShortcutItem.TargetInfo.IconLocation
             };
 
             var customShortcut = new OtherCustomShortcutBuilder(parameters).GenerateCustomShortcut(shortcutName);
@@ -276,7 +277,7 @@ namespace TileIconifier.Forms.Main
 
             try
             {
-                var customShortcut = CustomShortcut.Load(CurrentShortcutItem.TargetFilePath);
+                var customShortcut = CustomShortcut.Load(CurrentShortcutItem.TargetInfo.FilePath);
                 customShortcut.Delete();
             }
             catch (Exception ex)

--- a/TileIconifier/Forms/Main/FrmMainMethods.Designer.cs
+++ b/TileIconifier/Forms/Main/FrmMainMethods.Designer.cs
@@ -188,7 +188,7 @@ namespace TileIconifier.Forms.Main
                 textBox.ScrollToCaret();
             };
             updateTextBox(txtLnkPath, CurrentShortcutItem.ShortcutFileInfo.FullName);
-            updateTextBox(txtExePath, CurrentShortcutItem.TargetFilePath);
+            updateTextBox(txtExePath, CurrentShortcutItem.TargetInfo.FilePath);
 
             //only show remove if the icon is currently iconified
             btnRemove.Enabled = CurrentShortcutItem.IsIconified;
@@ -387,7 +387,7 @@ namespace TileIconifier.Forms.Main
         {
             return !_currentShortcutListViewItem.ShortcutItem.IsTileIconifierCustomShortcut
                    && ShortcutConstantsAndEnums.KnownShortcutTargetsWithIssues.Any(s =>
-                       _currentShortcutListViewItem.ShortcutItem.TargetFilePath.ToUpper().EndsWith(s.ToUpper()));
+                       _currentShortcutListViewItem.ShortcutItem.TargetInfo.FilePath.ToUpper().EndsWith(s.ToUpper()));
         }
     }
 }


### PR DESCRIPTION
This makes the _Quick Build Custom Shortcut_ button a little smarter and also pulls in the arguments. This was especially needed when creating tiles for Chrome apps.